### PR TITLE
Disable Ctrl-S in bash

### DIFF
--- a/bash_aliases
+++ b/bash_aliases
@@ -1,3 +1,5 @@
+# vim: set ft=sh:
+
 # Git shortcuts
 
 alias g='git'

--- a/bashrc_addons
+++ b/bashrc_addons
@@ -1,0 +1,6 @@
+# vim: set ft=sh:
+
+# Prevent CTRL-S from suspending the output stream
+stty stop '' -ixoff
+# Prevent CTRL-Q from waking up the output stream
+stty start '' -ixon


### PR DESCRIPTION
So that:
* the terminal doesn't get accidentally frozen
* can be re-used as key-binding