### PR TITLE
Disable wrapping by default, and other wrapping settings

### DIFF
--- a/bash_aliases_addons
+++ b/bash_aliases_addons
@@ -39,4 +39,3 @@ alias dk='docker'
 alias dc='docker-compose'
 alias rmimages='docker rmi $(docker images -a -q)'
 alias rmcontainers='docker rm $(docker ps -a -f status=exited -q)'
-

--- a/gitconfig
+++ b/gitconfig
@@ -37,4 +37,4 @@
 [push]
   default = simple
 [rerere]
-	enabled = true
+  enabled = true

--- a/vimrc
+++ b/vimrc
@@ -54,7 +54,6 @@ syntax on  " syntax highlighting
 set mouse=a " enable mouse mode
 
 set noerrorbells visualbell t_vb=    " Disable all bells
-set autoindent                       " remember indent after going to the next line
 set showcmd                          " show command that is being entered in the lower right
 set backspace=indent,eol,start       " Allow extended backspace behaviour
 set virtualedit=block                " allow placing the cursor after the last char
@@ -72,6 +71,14 @@ set hidden
 " position of the new split panes
 set splitbelow
 set splitright
+
+" --- Wrapping
+set autoindent  " Remember indent level after going to the next line.
+set nowrap " Do not visually wrap lines by default.
+set breakindent " Align visually wrapped lines with the original indentation.
+set linebreak " Break between words when wrapping (don't break within words).
+" toggle wrapping with leader-w
+nmap <silent> <leader>w :set wrap!<CR>
 
 " Remember cursor position when re-opening a file
 autocmd BufReadPost *
@@ -163,9 +170,10 @@ nmap <Leader>d :bd
 nmap <Leader>c gcc
 vmap <Leader>c gc
 
-" Remove excess whitespace
+" --- Whitespace
 set listchars=tab:»·,trail:·,extends:>,precedes:<
-nmap <silent> <leader>w :set nolist!<CR>
+" toggle hidden characters highlighting:
+nmap <silent> <Leader>h :set nolist!<CR>
 
 function! <SID>StripTrailingWhitespaces()
   let l = line(".")

--- a/vimrc
+++ b/vimrc
@@ -79,6 +79,11 @@ set breakindent " Align visually wrapped lines with the original indentation.
 set linebreak " Break between words when wrapping (don't break within words).
 " toggle wrapping with leader-w
 nmap <silent> <leader>w :set wrap!<CR>
+" allow navigating 'visual lines' with j/k and up/down, instead of actual lines
+nnoremap j gj
+nnoremap k gk
+nnoremap <Down> gj
+nnoremap <Up> gk
 
 " Remember cursor position when re-opening a file
 autocmd BufReadPost *


### PR DESCRIPTION
The `leader-w` mapping is now used to toggle wrapping, that so far
was assigned to "toggle whitespace highlighting".
The latter has now been - tentatively - assigned to `leader-h`
(for "highlight").