### PR TITLE
vim: Remove defaults-breaking mappings for home and end

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -35,10 +35,6 @@ nmap <S-Tab> :bprev<CR>
 nmap <C-K> :bnext<CR>
 nmap <C-J> :bprev<CR>
 
-" map `=` and `-`  to end and beginning of line
-nnoremap = $
-nnoremap - 0
-
 " Map l key to right pane and h key to left pane
 map <C-L> <C-w>w
 map <C-H> <C-w>p


### PR DESCRIPTION
Though I can understand the convenience of these mappings, I propose to remove them, in the effort to make this vim configuration as acceptable as possible to those who rely on vanilla Vim.

* `-` is previous line
* `=` if remapped, breaks `==`, which is "automatically indent the current line" (this is kind of a big deal)


To soften the blow, consider the following:
* Vim (as opposed to Vi) also natively supports `Home` and `End` keys, with the same functionality as `0` and `$`, with the advantage of working both in normal and insert mode. In Mac `Home` and `End` are `Fn-Left` and `Fn-Right` 
* in a forthcoming PR we will provide improved `Home` key (which will toggle between first column and first non blank character like in other popular editors)
* we will also add the ability to load an additional, custom `vimrc`, so that one can still maintain additional configuration of their own