### PR TITLE
Remove Ctrl-L because it breaks the default (clear/redraw)

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -35,10 +35,6 @@ nmap <S-Tab> :bprev<CR>
 nmap <C-K> :bnext<CR>
 nmap <C-J> :bprev<CR>
 
-" Map l key to right pane and h key to left pane
-map <C-L> <C-w>w
-map <C-H> <C-w>p
-
 set number
 
 set cursorline


### PR DESCRIPTION
Ctrl-L in Vim works with the same principle as in Bash:
to clear the view, which in Vim means "nohighlight" and "redraw".

Overriding it removes an important functionality for those who rely on
vanilla Vim.

However, these dotfiles already provide an unobtrusive setting
(Alt-Right and Alt-Left) which can be used with the same purpose (they
also work seamlessly between Tmux and Vim).