### PR TITLE
vim: Enhance search and search+replace for visual mode

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -98,6 +98,70 @@ hi Search term=reverse cterm=reverse ctermbg=8 ctermfg=3
 " search and replace current word
 nnoremap <Leader>r :%s/\<<C-r><C-w>\>/
 
+" ----------------------------------- "
+" --- Search for visual selection --- "
+" ----------------------------------- "
+
+" <http://vim.wikia.com/wiki/Search_for_visually_selected_text>
+" <http://vim.wikia.com/wiki/VimTip171>
+" Search for selected text, forwards or backwards. It is case insensitive, and
+" any whitespace is matched ('hello\nworld' matches 'hello world')
+vnoremap <silent> * :<C-U>
+  \let old_reg=getreg('"')<Bar>let old_regtype=getregtype('"')<CR>
+  \gvy/<C-R><C-R>=substitute(
+  \escape(@", '/\.*$^~['), '\_s\+', '\\_s\\+', 'g')<CR><CR>
+  \gV:call setreg('"', old_reg, old_regtype)<CR>
+
+vnoremap <silent> # :<C-U>
+  \let old_reg=getreg('"')<Bar>let old_regtype=getregtype('"')<CR>
+  \gvy?<C-R><C-R>=substitute(
+  \escape(@", '?\.*$^~['), '\_s\+', '\\_s\\+', 'g')<CR><CR>
+  \gV:call setreg('"', old_reg, old_regtype)<CR>
+
+" ------------------------------------------- "
+" --- Search and replace visual selection --- "
+" ------------------------------------------- "
+
+" https://github.com/bryankennedy/vimrc/blob/master/vimrc
+
+" Escape special characters in a string for exact matching.
+" This is useful to copying strings from the file to the search tool
+" Based on this - http://peterodding.com/code/vim/profile/autoload/xolox/escape.vim
+function! EscapeString (string)
+  let string=a:string
+  " Escape regex characters
+  let string = escape(string, '^$.*\/~[]')
+  " Escape the line endings
+  let string = substitute(string, '\n', '\\n', 'g')
+  return string
+endfunction
+
+" This function passed the visual block through a string escape function
+" Based on http://stackoverflow.com/questions/676600/vim-replace-selected-text/677918#677918
+function! GetVisual() range
+  " Save the current register and clipboard
+  let reg_save = getreg('"')
+  let regtype_save = getregtype('"')
+  let cb_save = &clipboard
+  set clipboard&
+
+  " Put the current visual selection in the " register
+  normal! ""gvy
+  let selection = getreg('"')
+
+  " Put the saved registers and clipboards back
+  call setreg('"', reg_save, regtype_save)
+  let &clipboard = cb_save
+
+  "Escape any special characters in the selection
+  let escaped_selection = EscapeString(selection)
+
+  return escaped_selection
+endfunction
+
+" Start the find and replace command across the entire file
+vnoremap <Leader>r <Esc>:%s/<c-r>=GetVisual()<cr>//c<Left><Left>
+
 " --------------------- "
 " --- Mouse support --- "
 " --------------------- "


### PR DESCRIPTION
Taken from bouncing-vim, but C-r has been changed to Leader-r to match existing shortcut for insert mode
