### PR TITLE
vim: Ignore spaces entered into ctrl+p file search

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -221,6 +221,17 @@ if executable('ag')
         \' --ignore=tags'
 endif
 
+let g:ctrlp_abbrev = {
+  \ 'gmode': 'i',
+  \ 'abbrevs': [
+    \ {
+      \ 'pattern': ' ',
+      \ 'expanded': '',
+      \ 'mode': 'pfrz',
+    \ },
+    \ ]
+  \ }
+
 " use ctrlp in a single shortcut to navigate buffers
 noremap <Leader>b :CtrlPBuffer<CR>
 

--- a/vimrc
+++ b/vimrc
@@ -221,6 +221,11 @@ if executable('ag')
         \' --ignore=tags'
 endif
 
+" Ignore space chars in file finder by designating spaces as an abbreviation
+" for empty string that's expanded in fuzzy search, filename, full path &
+" regexp modes (set in the mode attr).
+" https://github.com/kien/ctrlp.vim/blob/master/doc/ctrlp.txt
+" Fixes fuzzy searching files with space seperated terms
 let g:ctrlp_abbrev = {
   \ 'gmode': 'i',
   \ 'abbrevs': [


### PR DESCRIPTION
I've come from using fuzzy-search in Atom where spaces are used between chunks of text to search files

- i.e. ap con appl -> app/controllers/application_controller

The default ctrl-p file finder regex doesn't work like this, spaces are treated as whitespace in the filenme, so I keep failing to find files.

This changes how the file finder treats spaces so it won't break