### PR TITLE
Tmux pane setup script

### DIFF
--- a/scripts/dev
+++ b/scripts/dev
@@ -3,7 +3,7 @@
 tmux new-session -d
 tmux send-keys -t 0 "cd ~/neptune; vim" enter
 tmux new-window
-tmux split-window -v -p 10
+tmux split-window -v -p 30
 tmux select-pane -t 0
 tmux split-window -h -p 50
 tmux send-keys -t 0 "cd ~/neptune/; docker-compose up" enter

--- a/scripts/dev
+++ b/scripts/dev
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+tmux new-session -d
+tmux send-keys -t 0 "cd ~/neptune; vim" enter
+tmux new-window
+tmux split-window -v -p 10
+tmux select-pane -t 0
+tmux split-window -h -p 50
+tmux send-keys -t 0 "cd ~/neptune/; docker-compose up" enter
+tmux send-keys -t 1 "cd ~/neptune/" enter
+tmux send-keys -t 2 "cd ~/neptune/" enter
+tmux -2 attach-session -d


### PR DESCRIPTION
This is a dev set up script I'm using for Tmux that should simplify where to find things in a typical workflow e.g. Where is the server running, where is Vim, where is the CLI for the DB etc? There's two windows, one for vim and the second for the server and two other shells (for things like running tests, connecting to the DB etc)

Only issue with it is my neptune directory is in the root of my machine, so either the script will have to be altered or if you're going to be using this then move neptune to the home directory of the VM

<img width="1440" alt="screen shot 2017-11-04 at 18 45 12" src="https://user-images.githubusercontent.com/17249346/32408480-54b3d712-c190-11e7-879f-59b295063959.png">
