### PR TITLE
Allow ctrlp to select the same buffer in a difference split

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -516,6 +516,7 @@ let g:ctrlp_abbrev = {
 
 " use ctrlp in a single shortcut to navigate buffers
 noremap <Leader>b :CtrlPBuffer<CR>
+let g:ctrlp_switch_buffer = 0
 
 " ---------------------- "
 " --- vim-commentary --- "


### PR DESCRIPTION
without jumping to the buffer in the existing split.
Especially convenient for ctrlp huffer selection.