### PR TITLE
Add a global gitignore & setup

### DIFF
--- a/gitignore_global
+++ b/gitignore_global
@@ -1,0 +1,17 @@
+# Global gitignore config
+
+# OSX hidden files
+.DS_Store
+Thumbs.db
+.Spotlight-V100
+
+# Unix swap & temp files
+*.swp
+*~
+
+# Ruby specific
+.sass-cache
+.bundle
+gems.tags
+tags
+

--- a/scripts/setup
+++ b/scripts/setup
@@ -35,6 +35,7 @@ sudo npm install eslint --global
 
 # Dotfiles
 backup_and_symlink $ROOTDIR/gitconfig_addons $HOME/.gitconfig_addons
+backup_and_symlink $ROOTDIR/gitignore_global $HOME/.gitignore_global
 backup_and_symlink $ROOTDIR/bash_aliases_addons $HOME/.bash_aliases_addons
 backup_and_symlink $ROOTDIR/bashrc_addons $HOME/.bashrc_addons
 backup_and_symlink $ROOTDIR/tmux.conf $HOME/.tmux.conf
@@ -46,6 +47,7 @@ append_if_missing "$HOME/.bashrc" '[[ -e "${HOME}/.bash_aliases_addons" ]] && so
 
 # Git
 git config --global include.path .gitconfig_addons
+git config --global core.excludesfile '~/.gitignore_global'
 
 # Vim
 curl -fLo ~/.vim/autoload/plug.vim --create-dirs \


### PR DESCRIPTION
So I was changing the .gitignore for special-adventure, & @mikejustdoit said that the changes better suited to be in a global gitignore (as they were OSX hidden file exclusions)

https://github.com/ygt/special-adventure/pull/108

So here's a global .gitignore for us all, up for suggestions on what to add/remove from this, but quite keen to keep the amount quite short, or at least be very certain that the same ignore applies to all projects & hosts