### PR TITLE
Re-enable regex based ag search

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -471,7 +471,7 @@ let s:agignore =
 " ----------- "
 
 if executable('ag')
-  let g:ackprg = 'ag --hidden --follow --smart-case --skip-vcs-ignores --literal' . s:agignore
+  let g:ackprg = 'ag --hidden --follow --smart-case --skip-vcs-ignores' . s:agignore
 endif
 " do no jump to the first result
 cnoreabbrev Ack Ack!


### PR DESCRIPTION
Because it cannot be reverted on a per-command basis