### PR TITLE
Always grab the `SSH_AUTH_SOCK` on new window

### DIFF
--- a/bashrc_addons
+++ b/bashrc_addons
@@ -17,14 +17,6 @@ stty stop '' -ixoff
 # Prevent CTRL-Q from waking up the output stream
 stty start '' -ixon
 
-# -----------
-# --- SSH ---
-# -----------
-
-if [[ -S "$SSH_AUTH_SOCK" && ! -h "$SSH_AUTH_SOCK" ]]; then
-  ln -sf "$SSH_AUTH_SOCK" ~/.ssh/ssh_auth_sock;
-fi
-
 # ------------
 # --- Tmux ---
 # ------------
@@ -39,7 +31,26 @@ if [[ -n "$TMUX" ]]; then
   export TERM=screen-256color
 else
   export TERM=xterm-256color
+
 fi
+
+update_auth_sock() {
+  local socket_path="$(tmux show-environment | sed -n 's/^SSH_AUTH_SOCK=//p')"
+
+  if [[ -n "$TMUX" ]]; then
+    echo "not in a tmux session" >&2
+    return 1
+  fi
+
+  if [[ -n "$socket_path" ]]; then
+    echo "no socket path" >&2
+    return 1
+  else
+    export SSH_AUTH_SOCK="$socket_path"
+  fi
+}
+
+update_auth_sock()
 
 # ------------------------
 # --- Google Cloud SDK ---

--- a/tmux.conf
+++ b/tmux.conf
@@ -138,11 +138,3 @@ unbind p
 bind p paste-buffer
 # give 'v' to the user that still needs to go to the previous buffer
 bind v previous-window
-
-# ----------------- #
-# --- SSH agent --- #
-# ----------------- #
-
-# always use the SSH agent of the user that starts the tmux session
-# see the bashrc addons, where the local symlink to the socket is created
-setenv -g SSH_AUTH_SOCK $HOME/.ssh/ssh_auth_sock


### PR DESCRIPTION
On new window grab the `SSH_AUTH_SOCK` from the environment and set it on the session. I imagine however this does not resolve the issue when rejoining a session after a loss of an SSH connection. However this has been implemented as a function so it can be re-run whenever